### PR TITLE
Fetch genomes by assembly_uuid and organisms counts by species_taxonomy_id

### DIFF
--- a/src/ensembl/production/metadata/api/genome.py
+++ b/src/ensembl/production/metadata/api/genome.py
@@ -591,7 +591,7 @@ class GenomeAdaptor(BaseAdaptor):
         except Exception as e:
             raise ValueError(str(e))
 
-    def fetch_organisms_group_counts(self, release_version=None, group_code='popular'):
+    def fetch_organisms_group_counts(self, species_taxonomy_id=None, release_version=None, group_code='popular'):
         o_species = aliased(Organism)
         o = aliased(Organism)
         if not release_version:
@@ -612,6 +612,10 @@ class GenomeAdaptor(BaseAdaptor):
             query = query.join(OrganismGroup,
                                OrganismGroupMember.organism_group_id == OrganismGroup.organism_group_id)
             query = query.filter(OrganismGroup.code == group_code)
+
+            if species_taxonomy_id is not None:
+                query = query.filter(o_species.species_taxonomy_id == species_taxonomy_id)
+
             query = query.group_by(
                 o_species.species_taxonomy_id,
                 o_species.ensembl_name,
@@ -628,26 +632,3 @@ class GenomeAdaptor(BaseAdaptor):
         with self.metadata_db.session_scope() as session:
             # TODO check if we should return a dictionary instead
             return session.execute(query).all()
-
-    # def fetch_related_assemblies_count(self, species_taxonomy_id=None, release_version=None, group_code='popular'):
-    #
-    #     species_taxonomy_id = check_parameter(species_taxonomy_id)
-    #
-    #     count_expr = db.func.count().label('count')
-    #
-    #     if not release_version:
-    #         query = (
-    #             db.select(Organism, count_expr)
-    #             .filter(Organism.species_taxonomy_id == species_taxonomy_id)
-    #             # .group_by(Organism)
-    #         )
-    #
-    #         # if species_taxonomy_id is not None:
-    #         #     query = query.filter(Organism.species_taxonomy_id.in_(species_taxonomy_id))
-    #
-    #         print("\n")
-    #         print(f"query ===> {query}")
-    #         print("\n")
-    #         with self.metadata_db.session_scope() as session:
-    #             session.expire_on_commit = False
-    #             return session.execute(query).all()

--- a/src/ensembl/production/metadata/api/genome.py
+++ b/src/ensembl/production/metadata/api/genome.py
@@ -76,10 +76,10 @@ class GenomeAdaptor(BaseAdaptor):
                 taxids.append(taxid[0])
         return taxids
 
-    def fetch_genomes(self, genome_id=None, genome_uuid=None, organism_uuid=None, assembly_accession=None,
-                      assembly_name=None, use_default_assembly=False, ensembl_name=None, taxonomy_id=None,
-                      group=None, group_type=None, allow_unreleased=False, unreleased_only=False, site_name=None,
-                      release_type=None, release_version=None, current_only=True):
+    def fetch_genomes(self, genome_id=None, genome_uuid=None, organism_uuid=None, assembly_uuid=None,
+                      assembly_accession=None, assembly_name=None, use_default_assembly=False, ensembl_name=None,
+                      taxonomy_id=None, group=None, group_type=None, allow_unreleased=False, unreleased_only=False,
+                      site_name=None, release_type=None, release_version=None, current_only=True):
         """
         Fetches genome information based on the specified parameters.
 
@@ -87,6 +87,7 @@ class GenomeAdaptor(BaseAdaptor):
             genome_id (Union[int, List[int]]): The ID(s) of the genome(s) to fetch.
             genome_uuid (Union[str, List[str]]): The UUID(s) of the genome(s) to fetch.
             organism_uuid (Union[str, List[str]]): The UUID(s) of the organism(s) to fetch.
+            assembly_uuid (Union[str, List[str]]): The UUID(s) of the assembly(s) to fetch.
             assembly_accession (Union[str, List[str]]): The assenbly accession of the assembly(s) to fetch.
             assembly_name (Union[str, List[str]]): The name(s) of the assembly(s) to fetch.
             use_default_assembly (bool): Whether to use default assembly name or not.
@@ -123,6 +124,7 @@ class GenomeAdaptor(BaseAdaptor):
         genome_id = check_parameter(genome_id)
         genome_uuid = check_parameter(genome_uuid)
         organism_uuid = check_parameter(organism_uuid)
+        assembly_uuid = check_parameter(assembly_uuid)
         assembly_accession = check_parameter(assembly_accession)
         assembly_name = check_parameter(assembly_name)
         ensembl_name = check_parameter(ensembl_name)
@@ -156,6 +158,9 @@ class GenomeAdaptor(BaseAdaptor):
 
         if organism_uuid is not None:
             genome_select = genome_select.filter(Organism.organism_uuid.in_(organism_uuid))
+
+        if assembly_uuid is not None:
+            genome_select = genome_select.filter(Assembly.assembly_uuid.in_(assembly_uuid))
 
         if assembly_accession is not None:
             genome_select = genome_select.filter(Assembly.accession.in_(assembly_accession))
@@ -623,3 +628,26 @@ class GenomeAdaptor(BaseAdaptor):
         with self.metadata_db.session_scope() as session:
             # TODO check if we should return a dictionary instead
             return session.execute(query).all()
+
+    # def fetch_related_assemblies_count(self, species_taxonomy_id=None, release_version=None, group_code='popular'):
+    #
+    #     species_taxonomy_id = check_parameter(species_taxonomy_id)
+    #
+    #     count_expr = db.func.count().label('count')
+    #
+    #     if not release_version:
+    #         query = (
+    #             db.select(Organism, count_expr)
+    #             .filter(Organism.species_taxonomy_id == species_taxonomy_id)
+    #             # .group_by(Organism)
+    #         )
+    #
+    #         # if species_taxonomy_id is not None:
+    #         #     query = query.filter(Organism.species_taxonomy_id.in_(species_taxonomy_id))
+    #
+    #         print("\n")
+    #         print(f"query ===> {query}")
+    #         print("\n")
+    #         with self.metadata_db.session_scope() as session:
+    #             session.expire_on_commit = False
+    #             return session.execute(query).all()

--- a/src/tests/test_api.py
+++ b/src/tests/test_api.py
@@ -312,14 +312,24 @@ class TestMetadataDB:
         )
         assert len(test) == 0
 
-    def test_popular_species(self, multi_dbs):
+    @pytest.mark.parametrize(
+        "species_taxonomy_id, expected_organism, expected_assemblies_count",
+        [
+            # fetch everything
+            (None, "Human", 3),
+            # fetch Triticum aestivum only
+            (4565, "Triticum aestivum", 1),
+        ]
+    )
+    def test_fetch_organisms_group_counts(self, multi_dbs, species_taxonomy_id, expected_organism, expected_assemblies_count):
         conn = GenomeAdaptor(metadata_uri=multi_dbs['ensembl_metadata'].dbc.url,
                              taxonomy_uri=multi_dbs['ncbi_taxonomy'].dbc.url)
-        test = conn.fetch_organisms_group_counts()
+        test = conn.fetch_organisms_group_counts(species_taxonomy_id=species_taxonomy_id)
+        # When fetching everything:
         # First result should be Human
-        assert test[0][2] == 'Human'
+        assert test[0][2] == expected_organism
         # We should have three assemblies associated with Human (Two for grch37.38 organism + one t2t)
-        assert test[0][5] == 3
+        assert test[0][5] == expected_assemblies_count
         for data in test[1:]:
             # All others have only one genome in test DB
             assert data[5] == 1


### PR DESCRIPTION
### JIRA Tickets
* https://www.ebi.ac.uk/panda/jira/browse/EA-1105
* https://www.ebi.ac.uk/panda/jira/browse/EA-1107

### Changes
* Update the API to be able to:
  * Fetch genomes using `assembly_uuid` (needed in [EA-1105](https://www.ebi.ac.uk/panda/jira/browse/EA-1105))
  * Fetch organisms group counts using `species_taxonomy_id` (needed in [EA-1107](https://www.ebi.ac.uk/panda/jira/browse/EA-1107))
* Update tests

### Related PR
TBA
