### PR TITLE
Moved reflection package yagrc to test.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<<<<<<< HEAD
 # Ensembl Metadata API / GRPC API 
 # SQLAlchemy ORM for the Ensembl Metadata database.
 # GRPC Service protofile to interact with metadata database through GRPC
@@ -55,8 +54,6 @@ workon ensembl_metadata_api
 pip install --upgrade pip
 pip install -r requirements-dev.txt
 ```
-
-=======
 To generate client and server files
 (Remember to run these after adding a new method in ensembl_metadata.proto)
 ```
@@ -138,7 +135,7 @@ mypy src
 ```
 Pylint will check the code for syntax, name errors and formatting style.
 Mypy will use type hints to statically type check the code.
-=======
+
 cd ensembl-metadata-service
 pylint src tests
 mypy src tests
@@ -153,5 +150,5 @@ docker build -t ensembl-metadata-service .
 
 ### To run docker container
 ```
- docker run -t -i -e METADATA_URI=<URI> -e TAXONOMY_URI=<URI> -p 80:80 ensembl-metadata-service
+ docker run -t -i -e METADATA_URI=<URI> -e TAXONOMY_URI=<URI> -p 80:80 ensembl-metadata-api
 ```

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ pylint
 mypy
 coverage[toml]
 pytest-grpc
+yagrc==1.1.2

--- a/requirements.in
+++ b/requirements.in
@@ -4,4 +4,3 @@ grpcio-tools
 grpcio-reflection
 sqlalchemy
 types-pymysql
-yagrc

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,11 +21,8 @@ grpcio==1.62.0
     #   -r requirements.in
     #   grpcio-reflection
     #   grpcio-tools
-    #   yagrc
 grpcio-reflection==1.62.0
-    # via
-    #   -r requirements.in
-    #   yagrc
+    # via -r requirements.in
 grpcio-tools==1.62.0
     # via -r requirements.in
 idna==3.6
@@ -42,8 +39,7 @@ protobuf==4.25.3
     # via
     #   grpcio-reflection
     #   grpcio-tools
-    #   yagrc
-pytest==8.0.1
+pytest==8.0.2
     # via
     #   ensembl-py
     #   pytest-dependency
@@ -68,8 +64,6 @@ types-pymysql==1.1.0.1
     # via -r requirements.in
 urllib3==2.2.1
     # via requests
-yagrc==1.1.2
-    # via -r requirements.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/src/ensembl/production/metadata/api/models/dataset.py
+++ b/src/ensembl/production/metadata/api/models/dataset.py
@@ -48,7 +48,8 @@ class Dataset(LoadAble, Base):
     created = Column(DATETIME(fsp=6), server_default=func.now(), default=datetime.datetime.utcnow)
     dataset_source_id = Column(ForeignKey('dataset_source.dataset_source_id'), nullable=False, index=True)
     label = Column(String(128), nullable=False)
-    status = Column(Enum('Submitted', 'Progressing', 'Processed'), server_default=text("'Submitted'"))
+    status = Column(Enum('Submitted', 'Progressing', 'Processed', 'Released'),
+                    server_default=text("'Submitted'"))
 
     # One to many relationships
     # dataset_id to dataset attribute and genome dataset

--- a/src/ensembl/production/metadata/grpc/config.py
+++ b/src/ensembl/production/metadata/grpc/config.py
@@ -59,3 +59,4 @@ class MetadataConfig:
         self.pool_recycle = os.environ.get("POOL_RECYCLE", 50)
         self.allow_unreleased = parse_boolean_var(os.environ.get("ALLOW_UNRELEASED", False))
         self.debug_mode = parse_boolean_var(os.environ.get("DEBUG", False))
+        self.service_port = int(os.environ.get("SERVICE_PORT", 50051))

--- a/src/ensembl/production/metadata/grpc/service.py
+++ b/src/ensembl/production/metadata/grpc/service.py
@@ -39,13 +39,11 @@ def serve():
         reflection.SERVICE_NAME
     )
     reflection.enable_server_reflection(SERVICE_NAMES, server)
-    server.add_insecure_port("[::]:50051")
+    server.add_insecure_port(f"[::]:{cfg.service_port}")
     server.start()
     try:
-        logger.info(f"Starting GRPC Server from {cfg.metadata_uri}")
-        logger.info(f"DEBUG: {cfg.debug_mode}")
+        logger.info(f"Starting GRPC Server on {cfg.service_port} DEBUG: {cfg.debug_mode}")
         server.wait_for_termination()
-        yield server
     except KeyboardInterrupt:
         logger.info("KeyboardInterrupt caught, stopping the server...")
         server.stop(grace=0)  # Immediately stop the server
@@ -53,5 +51,5 @@ def serve():
 
 
 if __name__ == "__main__":
-    logger.info("gRPC server starting on port 50051...")
+    logger.info(f"gRPC server starting...")
     serve()


### PR DESCRIPTION
Update dataset status enum
Removed `yield` from service start up method
Moved Config in server()
Added Configurable service port


For some reason `serve()` method failed to run with the `yield` keyword. From https://github.com/grpc/grpc/blob/master/examples/python/wait_for_ready/wait_for_ready_with_client_timeout_example_server.py it seems like it's not necessary so I removed it.  Now the Docker container run as expected. 

I took this chance as well to make the `service_port` configurable with default to standard 50051 one. 