### PR TITLE
Fix a bug where `dataset_type_name` is an empty srting

### DIFF
--- a/src/ensembl/production/metadata/grpc/adaptors/genome.py
+++ b/src/ensembl/production/metadata/grpc/adaptors/genome.py
@@ -531,7 +531,7 @@ class GenomeAdaptor(BaseAdaptor):
                     genome_select = genome_select.filter(Dataset.dataset_uuid.in_(dataset_uuid))
                 else:
                     genome_select = genome_select.filter(Dataset.dataset_uuid == dataset_uuid)
-            dataset_type_name = "assembly" if dataset_type_name is None else dataset_type_name
+            dataset_type_name = "assembly" if not dataset_type_name else dataset_type_name
             if dataset_type_name == "all":
                 # TODO: fetch the list dynamically from the DB
                 # TODO: you can as well simply remove the filter, if you want them all.


### PR DESCRIPTION
It's a tiny bug with an annoying outcome <sup>(*)</sup>
When `dataset_type` is not specified in the gRPC request
```
{
    "genome_uuid": "a7335667-93e7-11ec-a39d-005056b38ce3"
}
```

`dataset_type_name` in this line will be an empty string
```
dataset_type_name = "assembly" if not dataset_type_name else dataset_type_name
```
Causing the code to filter by `datatype.name == ''` which done exist --> returning no results
```
genome_select = genome_select.filter(DatasetType.name == dataset_type_name)
```

**Solution**:
```
dataset_type_name = "assembly" if not dataset_type_name else dataset_type_name
```
Takes care of both None and empty strings

---

<sup>(*)</sup> This bit of the code is used to fetch the release number for a given genome UUID (Used by thoas to connect to mongo DB)

