### PR TITLE
Fix related assemblies count by passing the missing taxonomy id

### DIFF
--- a/src/ensembl/production/metadata/grpc/utils.py
+++ b/src/ensembl/production/metadata/grpc/utils.py
@@ -133,7 +133,7 @@ def create_genome_with_attributes_and_count(db_conn, genome, release_version):
             attribs.extend(dataset.attributes)
 
     # fetch related assemblies count
-    related_assemblies_count = db_conn.fetch_assemblies_count(None)
+    related_assemblies_count = db_conn.fetch_assemblies_count(genome.Organism.taxonomy_id)
 
     alternative_names = get_alternative_names(db_conn, genome.Organism.taxonomy_id)
 

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -314,7 +314,8 @@ class TestUtils:
             ))
         logger.debug(f"Initial {output}")
         output = json.loads(output)
-        expected_keys = ['assembly', 'attributesInfo', 'created', 'genomeUuid', 'organism', 'release', 'taxon']
+        expected_keys = ['assembly', 'attributesInfo', 'created', 'genomeUuid',
+                         'organism', 'release', 'taxon', 'relatedAssembliesCount']
         logger.debug(f"Output {output}")
         if actual is not None:
             assert len(output.keys()) == len(expected_keys)
@@ -430,7 +431,8 @@ class TestUtils:
                 'scientificName': 'Homo sapiens',
                 'strain': 'Esan in Nigeria',
                 'taxonomyId': 9606
-            }
+            },
+            'relatedAssembliesCount': 5
         }
         assert json.loads(output) == expected_output
 
@@ -493,7 +495,8 @@ class TestUtils:
                 'scientificName': 'Caenorhabditis elegans',
                 'strain': 'N2',
                 'taxonomyId': 6239
-            }
+            },
+            'relatedAssembliesCount': 1
         }
         assert json.loads(output) == expected_output
 


### PR DESCRIPTION
### Jira Ticket
https://www.ebi.ac.uk/panda/jira/browse/EA-1229

### Example
#### Query
```
{
         "genome_uuid": "a7335667-93e7-11ec-a39d-005056b38ce3",
}
```

#### Response before the fix
```
{
	"genome_uuid": "a7335667-93e7-11ec-a39d-005056b38ce3",
	"assembly": {
		"accession": "GCA_000001405.29",
		"name": "GRCh38.p14",
		"ucsc_name": "hg38",
		"level": "chromosome",
		"ensembl_name": "GRCh38.p14",
		"assembly_uuid": "fd7fea38-981a-4d73-a879-6f9daef86f08",
		"is_reference": true,
		"url_name": "grch38",
		"tol_id": ""
	},
	"related_assemblies_count": 0,  <----- this should be 99 in this example
}
```
#### Response after
```
{
	"genome_uuid": "a7335667-93e7-11ec-a39d-005056b38ce3",
	"assembly": {
		"accession": "GCA_000001405.29",
		"name": "GRCh38.p14",
		"ucsc_name": "hg38",
		"level": "chromosome",
		"ensembl_name": "GRCh38.p14",
		"assembly_uuid": "fd7fea38-981a-4d73-a879-6f9daef86f08",
		"is_reference": true,
		"url_name": "grch38",
		"tol_id": ""
	},
	"related_assemblies_count": 99,  <----- all good
```
