### PR TITLE
Added optional release_id filter to genomes.py script

### DIFF
--- a/src/ensembl/production/metadata/api/factories/genomes.py
+++ b/src/ensembl/production/metadata/api/factories/genomes.py
@@ -105,6 +105,7 @@ class GenomeFactory:
             query = query.filter(~Genome.production_name.in_(filters.antispecies))
 
         if filters.release_id:
+            query = query.join(Genome.genome_releases)
             query = query.filter(GenomeDataset.release_id==filters.release_id)
             query = query.filter(GenomeRelease.release_id==filters.release_id)
 
@@ -129,7 +130,6 @@ class GenomeFactory:
             .join(OrganismGroupMember.organism_group) \
             .join(Genome.genome_datasets) \
             .join(GenomeDataset.dataset) \
-            .join(Genome.genome_releases) \
             .join(Dataset.dataset_source) \
             .join(Dataset.dataset_type) \
             .group_by(Genome.genome_id, Dataset.dataset_id) \

--- a/src/ensembl/production/metadata/api/factories/genomes.py
+++ b/src/ensembl/production/metadata/api/factories/genomes.py
@@ -27,7 +27,7 @@ from sqlalchemy import select
 
 from ensembl.production.metadata.api.factories.datasets import DatasetFactory
 from ensembl.production.metadata.api.models.dataset import DatasetType, Dataset, DatasetSource, DatasetStatus
-from ensembl.production.metadata.api.models.genome import Genome, GenomeDataset
+from ensembl.production.metadata.api.models.genome import Genome, GenomeDataset, GenomeRelease
 from ensembl.production.metadata.api.models.organism import Organism, OrganismGroup, OrganismGroupMember
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
@@ -44,6 +44,7 @@ class GenomeInputFilters:
     species: List[str] = field(default_factory=list)
     antispecies: List[str] = field(default_factory=list)
     dataset_status: List[str] = field(default_factory=lambda: ["Submitted"])
+    release_id: int = 0
     batch_size: int = 50
     page: int = 1
     organism_group_type: str = ''
@@ -103,6 +104,10 @@ class GenomeFactory:
         elif filters.antispecies:
             query = query.filter(~Genome.production_name.in_(filters.antispecies))
 
+        if filters.release_id:
+            query = query.filter(GenomeDataset.release_id==filters.release_id)
+            query = query.filter(GenomeRelease.release_id==filters.release_id)
+
         if filters.dataset_type:
             query = query.filter(Genome.genome_datasets.any(DatasetType.name.in_([filters.dataset_type])))
 
@@ -124,6 +129,7 @@ class GenomeFactory:
             .join(OrganismGroupMember.organism_group) \
             .join(Genome.genome_datasets) \
             .join(GenomeDataset.dataset) \
+            .join(Genome.genome_releases) \
             .join(Dataset.dataset_source) \
             .join(Dataset.dataset_type) \
             .group_by(Genome.genome_id, Dataset.dataset_id) \
@@ -195,6 +201,8 @@ def main():
                         help='List of Species Production names to filter the query. Default is an empty list.')
     parser.add_argument('--antispecies', type=str, nargs='*', default=[], required=False,
                         help='List of Species Production names to exclude from the query. Default is an empty list.')
+    parser.add_argument('--release_id', type=int, default=0, required=False,
+                        help='Genome_dataset release_id to filter the query. Default is 0 (no filter).')
     parser.add_argument('--dataset_status', nargs='*', default=["Submitted"],
                         choices=['Submitted', 'Processing', 'Processed', 'Released'], required=False,
                         help='List of dataset statuses to filter the query. Default is an empty list.')
@@ -231,6 +239,7 @@ def main():
                 species=args.species,
                 antispecies=args.antispecies,
                 batch_size=args.batch_size,
+                release_id=args.release_id,
                 dataset_status=args.dataset_status,
         ) or []:
             json.dump(genome, json_output)


### PR DESCRIPTION
While troubleshooting file production, I found this additional (and optional) filter criterion quite useful.

Not sure if we want to make it officially part of the `genomes.py` script.
Your call.

The test suite ran fin, but I added no specific tests for covering this TBH.
Focussing on `beta2` I could fetch the right number of data (genomes with "genebuild" dataset) out of the DB. 