### PR TITLE
Add `pymsql` missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ Mypy will use type hints to statically type check the code.
 
 ### To build docker image
 ```
-docker build -t ensembl-metadata-service .
+docker build -t ensembl-metadata-api .
 ```
 
 ### To run docker container
 ```
- docker run -t -i -e METADATA_URI=<URI> -e TAXONOMY_URI=<URI> -p 80:80 ensembl-metadata-api
+docker run -t -i -e METADATA_URI=<URI> -e TAXONOMY_URI=<URI> -p 80:80 ensembl-metadata-api
 ```

--- a/requirements.in
+++ b/requirements.in
@@ -8,3 +8,4 @@ grpcio-reflection
 sqlalchemy<=2.0
 types-pymysql
 urllib3~=1.26.15
+PyMySQL==1.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,6 +40,8 @@ protobuf==5.28.0
     #   -r requirements.in
     #   grpcio-reflection
     #   grpcio-tools
+pymysql==1.1.1
+    # via -r requirements.in
 pytest==8.3.3
     # via ensembl-utils
 python-dotenv==1.0.1


### PR DESCRIPTION
I was getting this error when trying to run `docker run`
```
docker run -t -i -e METADATA_URI=METADAT_URI_HERE -e TAXONOMY_URI=TAXONOMY_URI_HERE -p 80:80 ensembl-metadata-api
Traceback (most recent call last):
  File "/usr/src/app/src/ensembl/production/metadata/grpc/service.py", line 55, in <module>
    serve()
  File "/usr/src/app/src/ensembl/production/metadata/grpc/service.py", line 35, in serve
    EnsemblMetadataServicer(), server
  File "/usr/src/app/venv/lib/python3.10/site-packages/ensembl/production/metadata/grpc/servicer.py", line 22, in __init__
    self.db = utils.connect_to_db()
  File "/usr/src/app/venv/lib/python3.10/site-packages/ensembl/production/metadata/grpc/utils.py", line 26, in connect_to_db
    conn = GenomeAdaptor(
  File "/usr/src/app/venv/lib/python3.10/site-packages/ensembl/production/metadata/api/adaptors/genome.py", line 53, in __init__
    super().__init__(metadata_uri)
  File "/usr/src/app/venv/lib/python3.10/site-packages/ensembl/production/metadata/api/adaptors/base.py", line 24, in __init__
    self.metadata_db = DBConnection(metadata_uri, pool_size=cfg.pool_size, pool_recycle=cfg.pool_recycle)
  File "/usr/src/app/venv/lib/python3.10/site-packages/ensembl/utils/database/dbconnection.py", line 63, in __init__
    self._engine = create_engine(url, future=True, **kwargs)
  File "<string>", line 2, in create_engine
  File "/usr/src/app/venv/lib/python3.10/site-packages/sqlalchemy/util/deprecations.py", line 277, in warned
    return fn(*args, **kwargs)  # type: ignore[no-any-return]
  File "/usr/src/app/venv/lib/python3.10/site-packages/sqlalchemy/engine/create.py", line 605, in create_engine
    dbapi = dbapi_meth(**dbapi_args)
  File "/usr/src/app/venv/lib/python3.10/site-packages/sqlalchemy/dialects/mysql/pymysql.py", line 75, in import_dbapi
    return __import__("pymysql")
ModuleNotFoundError: No module named 'pymysql'
```

This PR fixes it.