### PR TITLE
Add new coordsystem name supscaffold

### DIFF
--- a/src/ensembl/production/metadata/api/models/assembly.py
+++ b/src/ensembl/production/metadata/api/models/assembly.py
@@ -69,7 +69,7 @@ class AssemblySequence(LoadAble, Base):
     # column need renaming as well
     sha512t24u = Column(String(128))
     type = Column(Enum('chromosome_group', 'plasmid', 'primary_assembly', 'contig', 'chromosome', 'scaffold', 'lrg',
-                       'supercontig'), server_default=text("'primary_assembly'"))
+                       'supercontig', 'supscaffold'), server_default=text("'primary_assembly'"))
     is_circular = Column(TINYINT(1), nullable=False, default=0)
     assembly = relationship('Assembly', back_populates="assembly_sequences")
 


### PR DESCRIPTION
Add Missing Coordinate name `supscaffold` to assembly sequence table 