### PR TITLE
Simplify how we fetch the integrated release

### DIFF
--- a/src/ensembl/production/metadata/grpc/utils.py
+++ b/src/ensembl/production/metadata/grpc/utils.py
@@ -307,11 +307,7 @@ def get_brief_genome_details_by_uuid(db_conn, genome_uuid_or_tag, release_versio
         logger.warning(f"Multiple results found for Genome UUID/Release version: {genome_uuid_or_tag}/{release_version}")
         # means that this genome is released in both a partial and integrated release
         # we get the integrated release specifically since it's the one we are interested in
-        genome_results = db_conn.fetch_genomes(
-            genome_tag=genome_uuid_or_tag,
-            release_type="integrated",
-            release_version=release_version
-        )
+        genome_results = [res for res in genome_results if res.EnsemblRelease.release_type == "integrated"]
 
     # Get the current (requested) genome
     current_genome = genome_results[0]


### PR DESCRIPTION
Simplify how we fetch the integrated release as @veidenberg recommended in [this comment](https://github.com/Ensembl/ensembl-metadata-api/pull/132#discussion_r2060032470).