### PR TITLE
EnsemblRelease.release_type data is lower case

### DIFF
--- a/src/ensembl/production/metadata/api/adaptors/genome.py
+++ b/src/ensembl/production/metadata/api/adaptors/genome.py
@@ -750,7 +750,7 @@ class GenomeAdaptor(BaseAdaptor):
                 except NoResultFound:
                     raise ValueError(f"Release {release_label} not found")
 
-                if rel_test.status != ReleaseStatus.RELEASED or rel_test.release_type != "Integrated":
+                if rel_test.status != ReleaseStatus.RELEASED or rel_test.release_type != "integrated":
                     raise ValueError(f"Release {release_label} is not a released integrated release")
 
                 query = query.where(GenomeRelease.release_id == rel_test.release_id)
@@ -759,7 +759,7 @@ class GenomeAdaptor(BaseAdaptor):
                     select(EnsemblRelease.release_id)
                     .where(
                         EnsemblRelease.status == ReleaseStatus.RELEASED,
-                        EnsemblRelease.release_type == "Integrated"
+                        EnsemblRelease.release_type == "integrated"
                     )
                     .order_by(desc(EnsemblRelease.release_date))
                     .limit(1)
@@ -776,7 +776,7 @@ class GenomeAdaptor(BaseAdaptor):
                         select(EnsemblRelease.release_id)
                         .where(
                             EnsemblRelease.status == ReleaseStatus.RELEASED,
-                            EnsemblRelease.release_type == "Partial",
+                            EnsemblRelease.release_type == "partial",
                             GenomeRelease.is_current.is_(True)  # Ensure we only get current partial releases
                         )
                         .join(GenomeRelease)  # Join to check is_current
@@ -791,7 +791,7 @@ class GenomeAdaptor(BaseAdaptor):
                 query = query.where(
                     or_(
                         and_(
-                            EnsemblRelease.release_type == "Partial",
+                            EnsemblRelease.release_type == "partial",
                             GenomeRelease.is_current.is_(True)
                         ),
                         EnsemblRelease.release_id == latest_release_id


### PR DESCRIPTION
Make the matches for EnsemblRelease.release_type lower case, since data in the DB is lower case.