### PR TITLE
Discarded two additional datasets

### DIFF
--- a/src/ensembl/production/metadata/api/models/genome.py
+++ b/src/ensembl/production/metadata/api/models/genome.py
@@ -72,7 +72,9 @@ class Genome(LoadAble, Base):
         common_path = f"{base_path}/{genebuild_source_name}"
         
         unique_dataset_types = {gd.dataset.dataset_type.name for gd in root_datasets}
-
+        unique_dataset_types.discard('vep_genome_feature')
+        unique_dataset_types.discard('vep_assembly_feature')
+        
         if 'regulatory_features' in unique_dataset_types or 'regulation_build' in unique_dataset_types:
             unique_dataset_types.discard('regulatory_features')
             unique_dataset_types.discard('regulation_build')

--- a/src/ensembl/production/metadata/api/models/genome.py
+++ b/src/ensembl/production/metadata/api/models/genome.py
@@ -72,9 +72,9 @@ class Genome(LoadAble, Base):
         common_path = f"{base_path}/{genebuild_source_name}"
         
         unique_dataset_types = {gd.dataset.dataset_type.name for gd in root_datasets}
-        unique_dataset_types.discard('vep_genome_feature')
-        unique_dataset_types.discard('vep_assembly_feature')
-        
+        if 'vep_genome_feature' in unique_dataset_types or 'vep_assembly_feature' in unique_dataset_types:
+            unique_dataset_types.discard('vep_genome_feature')
+            unique_dataset_types.discard('vep_assembly_feature')
         if 'regulatory_features' in unique_dataset_types or 'regulation_build' in unique_dataset_types:
             unique_dataset_types.discard('regulatory_features')
             unique_dataset_types.discard('regulation_build')


### PR DESCRIPTION
These are breaking the web page. It is likely do to multiple datasets of the same type existing.
Short term fix: Exclude these dataset types
Long term fix: get_public_path() should be moved out of models. It is inconsistent and overall pretty terrible.