### PR TITLE
Add location mapping for apicoplast_chromosome

### DIFF
--- a/src/ensembl/production/metadata/updater/core.py
+++ b/src/ensembl/production/metadata/updater/core.py
@@ -438,6 +438,7 @@ class CoreMetaUpdater(BaseMetaUpdater):
                     'nuclear_chromosome': 'SO:0000738',
                     'mitochondrial_chromosome': 'SO:0000737',
                     'chloroplast_chromosome': 'SO:0000745',
+                    'apicoplast_chromosome': 'SO:0001259',
                     None: 'SO:0000738',
                 }
                 # Try to get the sequence location


### PR DESCRIPTION

Added support for a new chromosome location value found in the **babesia_bovis_gca000165395v2_core_114_1** .

**Changes**
Updated the location_mapping dictionary in the metadata updater to include:

'apicoplast_chromosome': 'SO:0001259'
This maps the new location to the correct Sequence Ontology (SO) term: [SO:0001259](http://sequenceontology.org/browser/current_release/term/SO:0001259).

```
+----------+-----------------+---------+-----------------------+-------------------+
| name     | coord_system_id | length  | value                 | name              |
+----------+-----------------+---------+-----------------------+-------------------+
| CM031755 |               1 |   33351 | apicoplast_chromosome | sequence_location |
| CM031752 |               1 | 1246099 | nuclear_chromosome    | sequence_location |
| CM031753 |               1 | 1729419 | nuclear_chromosome    | sequence_location |
| CM031754 |               1 | 2593320 | nuclear_chromosome    | sequence_location |
+----------+-----------------+---------+-----------------------+-------------------+
```
New genome submitted by the genebuild `babesia_bovis_gca000165395v2_core_114_1`  has value `apicoplast_chromosome` which is not defined in metadata updater, added 'apicoplast_chromosome': 'SO:0001259', to location mapping from the source http://sequenceontology.org/browser/current_release/term/SO:0001259
