### PR TITLE
fix the organism scientific name for ftp path

### DIFF
--- a/src/ensembl/production/metadata/api/adaptors/genome.py
+++ b/src/ensembl/production/metadata/api/adaptors/genome.py
@@ -929,7 +929,9 @@ class GenomeAdaptor(BaseAdaptor):
             dataset_type = 'regulation'
         match = re.match(r'^(\d{4}-\d{2})', last_geneset_update)  # Match format YYYY-MM
         last_geneset_update = match.group(1).replace('-', '_')
+        scientific_name = re.sub(r'[^a-zA-Z0-9]+', ' ', scientific_name)
         scientific_name = scientific_name.replace(' ', '_')
+        scientific_name = re.sub(r'^_+|_+$', '', scientific_name)
         genebuild_source_name = genebuild_source_name.lower()
         base_path = f"{scientific_name}/{accession}"
         common_path = f"{base_path}/{genebuild_source_name}"


### PR DESCRIPTION
 Normalise scientific_name to match Perl logic from FTP dump pipeline

This PR updates the formatting of the scientific_name field to align with the behavior defined in the existing Perl code used in the FTP dump pipeline.

Changes:
The following transformations are applied to scientific_name:

Replace all non-alphanumeric characters with a space:
re.sub(r'[^a-zA-Z0-9]+', ' ', scientific_name)

Replace all spaces with underscores:
scientific_name.replace(' ', '_')

Trim leading and trailing underscores:
re.sub(r'^_+|_+$', '', scientific_name)


Ensure consistency between Python and Perl implementations of scientific_name normalization for compatibility with the FTP dump pipeline and downstream processes.

Example:
Input: "Aurelia sp. 4 Dawson et al 2005"
Output: "Aurelia_sp_4_Dawson_et_al_2005"

