### PR TITLE
Update error message for core updater

### DIFF
--- a/src/ensembl/production/metadata/updater/core.py
+++ b/src/ensembl/production/metadata/updater/core.py
@@ -150,7 +150,15 @@ class CoreMetaUpdater(BaseMetaUpdater):
 
         # If any species failed or were already loaded, raise an exception to prevent ignoring any errors
         if failed_species or already_loaded_species:
-            error_msg = f"Collection processing completed with issues: {len(failed_species)} failed, {len(already_loaded_species)} already loaded"
+            error_msg = f"""
+            Handover Failed For Genomes With Error:
+            {chr(10).join([f"- {fspecies[1]}: {fspecies[-1]}" for fspecies in failed_species])}
+
+            Collection processing completed with issues:
+            - {len(failed_species)} failed
+            - {len(already_loaded_species)} already loaded
+            """
+
             raise exceptions.MetadataUpdateException(error_msg)
 
     def _log_processing_summary(self, successful_species, failed_species, already_loaded_species):


### PR DESCRIPTION
## Summary
PR improves error reporting for genome handover jobs by generating a structured summary message whenever failures occur.  

## Changes
- Collects failed species in the form `(species_id, production_name, error_message)`.
- Generates a formatted error summary string:
  - Lists each failed species with its associated error message.

## Example Output
```text
Handover Failed For Genomes With Error:
- homo_sapiens: genebuild.stats.average_coding_exons_per_coding does not exist. Add it to the database and reload.
- mus_musculus: file missing

Collection processing completed with issues:
- 2 failed
- 1 already loaded