### PR TITLE
Species search sorting rule

### DIFF
--- a/src/ensembl/production/metadata/api/search/search.py
+++ b/src/ensembl/production/metadata/api/search/search.py
@@ -1095,8 +1095,7 @@ class GenomeSearchIndexer:
                             doc = self.create_search_document(
                                 metadata_session, taxonomy_session, genome, release
                             )
-                            entry = doc.to_search_entry()
-                            search_entries.append(entry)
+                            search_entries.append(doc)
                             total_processed += 1
 
                             if total_processed % 100 == 0:
@@ -1117,8 +1116,16 @@ class GenomeSearchIndexer:
                                 exception=e,
                             )
 
-                logger.info(f"Deduplicating {len(search_entries)} entries by url_name...")
-                processed_entries, num_cleared = self.deduplicator.deduplicate_by_url_name(search_entries)
+                                # sort GenomeSearchDocuments
+                search_entries = self.sort_results(search_entries)
+                
+                # convert to SearchEntry
+                # TODO turn to_search_entry into a model_serializer  
+                search_entries_as_search_entry = list(map(lambda d: d.to_search_entry(), search_entries))
+
+                # TODO alter this to be a reduce function, performed on GenomeSearchDocuments
+                logger.info(f"Deduplicating {len(search_entries_as_search_entry)} entries by url_name...")
+                processed_entries, num_cleared = self.deduplicator.deduplicate_by_url_name(search_entries_as_search_entry)
 
                 logger.info("Validating url_name uniqueness...")
                 self.deduplicator.validate_unique_url_names(processed_entries)
@@ -1134,8 +1141,6 @@ class GenomeSearchIndexer:
                     if raise_on_errors:
                         error_collection.raise_if_errors()
                 
-                processed_entries = self.sort_results(sort_results)
-
                 return SearchIndex(
                     name="ensemblNext",
                     release=newest_partial,

--- a/src/ensembl/production/metadata/api/search/search.py
+++ b/src/ensembl/production/metadata/api/search/search.py
@@ -921,9 +921,8 @@ class GenomeSearchIndexer:
                             doc = self.create_search_document(
                                 metadata_session, taxonomy_session, genome, release
                             )
-                            #entry = doc.to_search_entry()
-                            all_entries.append(doc)
 
+                            all_entries.append(doc)
                             if len(all_entries) % 100 == 0:
                                 logger.info(f"Collected {len(all_entries)} entries...")
 
@@ -946,8 +945,10 @@ class GenomeSearchIndexer:
                 all_entries = self.sort_results(all_entries)
                 
                 # convert to SearchEntry
+                # TODO turn to_search_entry into a model_serializer  
                 all_entries_as_search_entry = list(map(lambda d: d.to_search_entry(), all_entries))
 
+                # TODO alter this to be a reduce function, performed on GenomeSearchDocuments
                 logger.info(f"Deduplicating {len(all_entries_as_search_entry)} entries by url_name...")
                 processed_entries, num_cleared = self.deduplicator.deduplicate_by_url_name(all_entries_as_search_entry)
 

--- a/src/ensembl/production/metadata/api/search/search.py
+++ b/src/ensembl/production/metadata/api/search/search.py
@@ -921,8 +921,8 @@ class GenomeSearchIndexer:
                             doc = self.create_search_document(
                                 metadata_session, taxonomy_session, genome, release
                             )
-                            entry = doc.to_search_entry()
-                            all_entries.append(entry)
+                            #entry = doc.to_search_entry()
+                            all_entries.append(doc)
 
                             if len(all_entries) % 100 == 0:
                                 logger.info(f"Collected {len(all_entries)} entries...")
@@ -941,9 +941,15 @@ class GenomeSearchIndexer:
                                 error_message=f"Unexpected error: {str(e)}",
                                 exception=e,
                             )
+                
+                # sort GenomeSearchDocuments
+                all_entries = self.sort_results(all_entries)
+                
+                # convert to SearchEntry
+                all_entries_as_search_entry = list(map(lambda d: d.to_search_entry(), all_entries))
 
-                logger.info(f"Deduplicating {len(all_entries)} entries by url_name...")
-                processed_entries, num_cleared = self.deduplicator.deduplicate_by_url_name(all_entries)
+                logger.info(f"Deduplicating {len(all_entries_as_search_entry)} entries by url_name...")
+                processed_entries, num_cleared = self.deduplicator.deduplicate_by_url_name(all_entries_as_search_entry)
 
                 logger.info("Validating url_name uniqueness...")
                 self.deduplicator.validate_unique_url_names(processed_entries)
@@ -1014,6 +1020,43 @@ class GenomeSearchIndexer:
         else:
             logger.info(f"Using regular mode (<={stream_threshold} genomes)")
             return self.export_to_json(output_path, raise_on_errors, pretty_print)
+
+
+    def sort_results(self, docs: List[GenomeSearchDocument]) -> List[GenomeSearchDocument]:
+        """Return a sorted list of genomes.
+        Sorting is done by multiple fields in a specific order.
+        The multiple sorts leverage pythons > only comparison to ensure each
+        sort order is preserved then the next sort doesn't apply
+
+        String values are moved to lower as comparison is done on charactor
+        value and A-Z are lower value than a-z
+        z is used when a string value can be None, this prevents the sort from
+        failing and places any empty strings at the bottom of the sort
+        """
+        sorts = [
+            # Order by highest rank
+            (lambda g: g.rank, True),
+            # Bring any assembly with is_reference == True to the top of the list
+            (lambda g: 1 if g.is_reference else 0, True),
+            # order by release type, integrated first
+            (lambda g: g.first_release_type == "integrated", True),
+            # order by common name
+            (lambda g: g.common_name.lower() if g.common_name else 'z', False),
+            # order by scientific name
+            (lambda g: g.scientific_name.lower(), False),
+            # Order by type.value, putting Non values at the bottom of the list
+            (lambda g: g.strain_type.lower() if g.strain_type else 'z', False),
+            # Order by type.kind, putting None values at the bottom of the list
+            (lambda g: g.strain.lower() if g.strain else 'z', False),
+            # Ensure that related assemblies are grouped
+            (lambda g: g.organism_uuid, False),
+        ]
+        # apply in reverse order to ensure first is applied last
+        for key, reverse in reversed(sorts):
+            docs.sort(key=key, reverse=reverse)
+
+        return docs
+
 
     def get_search_index(self, raise_on_errors: bool = False) -> SearchIndex:
         """
@@ -1089,6 +1132,8 @@ class GenomeSearchIndexer:
 
                     if raise_on_errors:
                         error_collection.raise_if_errors()
+                
+                processed_entries = self.sort_results(sort_results)
 
                 return SearchIndex(
                     name="ensemblNext",


### PR DESCRIPTION
This PR brings in the sorting logic that currently lives in `ensembl_search_hub` into the species search dump script. The reason to do this is to ensure that genomes are in the correct order with pagination in place. 

Previously when pagination was not in place we were sorting the entire results before passing to the client. When enabling pagination it was discovered that for example GRCH38 is not in the first 100 humans which results in it not being the first two search results (as of release 2026-02-20). This PR corrects this issue.

The PR also contains some notes for improvements to the script. I will implement them in another PR as I do not want to slow down this PR as it blocks delivery of pagination and column sorting features

An example of this PR working can be found here 
http://paginated-species-search.review.ensembl.org/species-selector/search?species_taxonomy_id=9606&page=1
 