### PR TITLE
Update rank to match default order index

### DIFF
--- a/src/ensembl/production/metadata/api/search/search.py
+++ b/src/ensembl/production/metadata/api/search/search.py
@@ -943,6 +943,7 @@ class GenomeSearchIndexer:
                 
                 # sort GenomeSearchDocuments
                 all_entries = self.sort_results(all_entries)
+                all_entries = update_rank(all_entries)
                 
                 # convert to SearchEntry
                 # TODO turn to_search_entry into a model_serializer  
@@ -1058,7 +1059,6 @@ class GenomeSearchIndexer:
 
         return docs
 
-
     def get_search_index(self, raise_on_errors: bool = False) -> SearchIndex:
         """
         Main entry point to generate search index.
@@ -1118,6 +1118,7 @@ class GenomeSearchIndexer:
 
                                 # sort GenomeSearchDocuments
                 search_entries = self.sort_results(search_entries)
+                search_entries = update_rank(search_entries)
                 
                 # convert to SearchEntry
                 # TODO turn to_search_entry into a model_serializer  
@@ -1148,6 +1149,18 @@ class GenomeSearchIndexer:
                     entries=processed_entries,
                 )
 
+# ============================================================================
+# Default sort order untils
+# ============================================================================
+
+def update_rank(docs: List[GenomeSearchDocument]) -> List[GenomeSearchDocument]:
+    """
+    Updates rank based on array index. This will be used as the default sort column 
+    """
+    for i, d in enumerate(docs):
+        d.rank = i + 1
+    
+    return docs
 
 # ============================================================================
 # USAGE

--- a/src/tests/test_search.py
+++ b/src/tests/test_search.py
@@ -39,6 +39,7 @@ from ensembl.production.metadata.api.search.search import (
     ReleaseSelector,
     GenomeSearchIndexer,
     SearchIndex,
+    update_rank,
 )
 
 db_directory = Path(__file__).parent / "databases"
@@ -313,6 +314,69 @@ class TestGenomeSearchDocument:
         assert data["genome_uuid"] == "test-uuid"
         assert data["scientific_name"] == "Homo sapiens"
         assert data["is_reference"] is True
+
+    def test_rank_injection(self, test_dbs):
+        docs = [
+            GenomeSearchDocument(
+                genome_uuid="test-uuid",
+                scientific_name="Homo sapiens",
+                assembly_name="GRCh38",
+                accession="GCA_000001405.15",
+                is_reference=True,
+                species_taxonomy_id=9606,
+                taxonomy_id=9606,
+                organism_uuid="test-organism-uuid",
+                first_release_name="112",
+                first_release_type="integrated",
+                latest_release_name="112",
+                latest_release_type="integrated",
+                is_latest_release_current=1,
+                releases="112",
+                lineage_taxids=[9606],
+                lineage_name=["Homo sapiens"],
+                contig_n50=50000000,
+                coding_genes=20000,
+                genebuild_provider="Ensembl",
+                genebuild_method_display="Import",
+                rank=999,
+            ),
+            GenomeSearchDocument(
+                genome_uuid="test-uuid_2",
+                scientific_name="Homo sapiens",
+                assembly_name="GRCh38",
+                accession="GCA_000001405.15",
+                is_reference=True,
+                species_taxonomy_id=9606,
+                taxonomy_id=9606,
+                organism_uuid="test-organism-uuid",
+                first_release_name="112",
+                first_release_type="integrated",
+                latest_release_name="112",
+                latest_release_type="integrated",
+                is_latest_release_current=1,
+                releases="112",
+                lineage_taxids=[9606],
+                lineage_name=["Homo sapiens"],
+                contig_n50=50000000,
+                coding_genes=20000,
+                
+                genebuild_provider="Ensembl",
+                genebuild_method_display="Import",
+                rank=0,
+            )
+        ]
+        
+        assert docs[0].rank == 999
+        assert docs[1].rank == 0
+        
+        docs = update_rank(docs)
+        
+        assert docs[0].rank == 1
+        assert docs[1].rank == 2
+        
+        assert docs[0].genome_uuid == "test-uuid"
+        assert docs[1].genome_uuid == "test-uuid_2"
+        
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR adds `update_rank', a method that over writes the rank field with the genomes current index + 1. This will allow for search results to be returned in default order by using `sort=rank&order=asc`

An example is https://staging-2020.ensembl.org/api/search/genomes?query=fish&sort=rank&order=asc which currently returns the same results as https://beta.ensembl.org/api/search/genomes?query=fish