### PR TITLE
Add genome group ids to the search dump

### DIFF
--- a/src/ensembl/production/metadata/api/search/search.py
+++ b/src/ensembl/production/metadata/api/search/search.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Optional, List, Tuple, Iterator, Union
 
 from ensembl.utils.database import DBConnection
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session, joinedload
 
@@ -28,6 +28,7 @@ from ensembl.production.metadata.api.models import (
     DatasetAttribute,
     EnsemblRelease,
     GenomeRelease,
+    GenomeGroupMember,
     GenomeDataset,
     ReleaseStatus,
     DatasetStatus,
@@ -150,6 +151,8 @@ class GenomeSearchDocument(BaseModel):
     # Additional taxonomy fields
     lineage_taxids: list[int]
     lineage_name: list[str]
+    # Stored as a list internally, but emitted as repeated "genome_group_ids" fields for search.
+    genome_group_ids: List[int] = Field(default_factory=list)
 
     # Complex derived fields from datasets - REQUIRED
     contig_n50: int
@@ -207,6 +210,12 @@ class GenomeSearchDocument(BaseModel):
             SearchField(name="is_latest_release_current", value=self.is_latest_release_current),
             SearchField(name="releases", value=self.releases),
         ]
+
+        # Search expects one field entry per genome group rather than a list-valued field.
+        fields.extend(
+            SearchField(name="genome_group_ids", value=genome_group_id)
+            for genome_group_id in self.genome_group_ids
+        )
 
         return SearchEntry(fields=fields)
 
@@ -672,6 +681,8 @@ class GenomeSearchIndexer:
                 .joinedload(Dataset.dataset_attributes)
                 .joinedload(DatasetAttribute.attribute),
                 joinedload(Genome.genome_datasets).joinedload(GenomeDataset.ensembl_release),
+                # Load group ids with each batch so dump generation does not lazy-load per genome.
+                joinedload(Genome.genome_group_members).joinedload(GenomeGroupMember.genome_group),
             )
             .all()
         )
@@ -739,7 +750,24 @@ class GenomeSearchIndexer:
             "scientific_parlance_name": genome.organism.scientific_parlance_name,
             "organism_uuid": genome.organism.organism_uuid,
             "rank": genome.organism.rank or 0,
+            "genome_group_ids": self._extract_genome_group_ids(genome),
         }
+
+    def _extract_genome_group_ids(self, genome: Genome) -> List[int]:
+        """Extract current genome group IDs for repeated search fields."""
+        genome_group_members = getattr(genome, "genome_group_members", []) or []
+        try:
+            genome_group_members = iter(genome_group_members)
+        except TypeError:
+            return []
+
+        # Limit the dump to active memberships and keep output stable for reproducible dumps.
+        genome_group_ids = {
+            ggm.genome_group.genome_group_id
+            for ggm in genome_group_members
+            if ggm.is_current == 1 and ggm.genome_group is not None
+        }
+        return sorted(genome_group_ids)
 
     def _get_taxonomy_lineage(
             self, taxonomy_session: Session, taxonomy_id: int

--- a/src/tests/test_search.py
+++ b/src/tests/test_search.py
@@ -241,6 +241,7 @@ class TestGenomeSearchDocument:
             has_regulation=True,
             genebuild_provider="Ensembl",
             genebuild_method_display="Import",
+            genome_group_ids=[1, 2],
         )
 
         assert doc.common_name == "Human"
@@ -248,6 +249,40 @@ class TestGenomeSearchDocument:
         assert doc.has_variation is True
         assert doc.has_regulation is True
         assert doc.rank == 10
+        assert doc.genome_group_ids == [1, 2]
+
+    def test_document_serializes_genome_group_ids_as_repeated_fields(self, test_dbs):
+        """Test genome group IDs are emitted as repeated search fields."""
+        doc = GenomeSearchDocument(
+            genome_uuid="test-uuid",
+            scientific_name="Homo sapiens",
+            assembly_name="GRCh38",
+            accession="GCA_000001405.15",
+            is_reference=True,
+            species_taxonomy_id=9606,
+            taxonomy_id=9606,
+            organism_uuid="test-organism-uuid",
+            first_release_name="112",
+            first_release_type="integrated",
+            latest_release_name="112",
+            latest_release_type="integrated",
+            is_latest_release_current=1,
+            releases="112",
+            lineage_taxids=[9606],
+            lineage_name=["Homo sapiens"],
+            contig_n50=50000000,
+            coding_genes=20000,
+            genebuild_provider="Ensembl",
+            genebuild_method_display="Import",
+            genome_group_ids=[1, 2],
+        )
+
+        entry = doc.to_search_entry()
+        genome_group_fields = [
+            field for field in entry.fields if field.name == "genome_group_ids"
+        ]
+
+        assert [field.value for field in genome_group_fields] == [1, 2]
 
     def test_document_missing_required_field(self, test_dbs):
         """Test document creation fails when required field is missing."""


### PR DESCRIPTION
### Changes

Added genome group ids to the search dump, they will look something like this:

```
        {
          "name": "genome_group_ids",
          "value": 1
        },
        {
          "name": "genome_group_ids",
          "value": 2
        },
        {
          "name": "genome_group_ids",
          "value": 3
        },
```