### PR TITLE
Update taxonomy dump logic and structure for search

### DIFF
--- a/src/ensembl/production/metadata/api/search/search.py
+++ b/src/ensembl/production/metadata/api/search/search.py
@@ -803,39 +803,46 @@ class GenomeSearchIndexer:
         try:
             ancestors = Taxonomy.fetch_ancestors(taxonomy_session, taxonomy_id)
         except NoResultFound:
-            ancestors = []
+            return {
+                "lineage_taxon_id": [taxonomy_id],
+                "lineage_common_name": [],
+                "lineage_scientific_name": [],
+            }
 
         # Build list of taxon_ids: current + all ancestors.
         lineage_taxon_ids = [taxonomy_id]
         for ancestor in ancestors:
             lineage_taxon_ids.append(ancestor["taxon_id"])
 
-        # Query scientific and common names for all taxon_ids in the lineage.
-        # TODO: Check if we need to extend this to include more name_classes or tweak filter by rank
+        selected_ranks = (
+            "domain",
+            "kingdom",
+            "phylum",
+            "class",
+            "order",
+            "family",
+            "genus",
+            "species",
+        )
+
+        # Query scientific and common names for selected ranks in the lineage.
         taxonomy_name_rows = (
             taxonomy_session.query(NCBITaxonomy.taxon_id, NCBITaxonomy.name, NCBITaxonomy.name_class)
             .filter(NCBITaxonomy.taxon_id.in_(lineage_taxon_ids))
             .filter(NCBITaxonomy.name_class.in_(("scientific name", "common name")))
-            # Exclude these ranks to limit noise
-            .filter(NCBITaxonomy.rank.notin_((
-                    "acronym", "authority", "blast name", "equivalent name", "genbank common name",
-                    "import date", "in-part", "includes", "merged_taxon_id", "synonym", "type material"
-                ))
-            ) 
+            .filter(NCBITaxonomy.rank.in_(selected_ranks))
             .distinct()
             .all()
         )
 
+        selected_taxon_ids = {taxon_id for taxon_id, name, name_class in taxonomy_name_rows}
+        lineage_taxon_ids = [taxon_id for taxon_id in lineage_taxon_ids if taxon_id in selected_taxon_ids]
         names_by_taxon_id = {
             taxon_id: {"common name": [], "scientific name": []} for taxon_id in lineage_taxon_ids
         }
-        # print(taxonomy_name_rows)
-        
+
         for taxon_id, name, name_class in taxonomy_name_rows:
             names_by_taxon_id[taxon_id][name_class].append(name)
-
-        from pprint import pprint
-        # pprint(names_by_taxon_id)
 
         lineage_common_names = []
         lineage_scientific_names = []
@@ -849,7 +856,7 @@ class GenomeSearchIndexer:
             "lineage_scientific_name": lineage_scientific_names,
         }
 
-        # logger.info(lineage_data)
+        # logger.debug(lineage_data)
         return lineage_data
 
     def create_search_document(

--- a/src/ensembl/production/metadata/api/search/search.py
+++ b/src/ensembl/production/metadata/api/search/search.py
@@ -148,9 +148,10 @@ class GenomeSearchDocument(BaseModel):
     organism_uuid: str  # Changed from organism_id
     rank: int = 0
 
-    # Additional taxonomy fields
-    lineage_taxids: list[int]
-    lineage_name: list[str]
+    # Additional taxonomy fields. Stored as lists internally, but emitted as repeated fields for search.
+    lineage_taxon_id: list[int]
+    lineage_common_name: list[str]
+    lineage_scientific_name: list[str]
     # Stored as a list internally, but emitted as repeated "genome_group_ids" fields for search.
     genome_group_ids: List[int] = Field(default_factory=list)
 
@@ -199,8 +200,6 @@ class GenomeSearchDocument(BaseModel):
             SearchField(name="is_reference", value=self.is_reference),
             SearchField(name="species_taxonomy_id", value=self.species_taxonomy_id),
             SearchField(name="taxonomy_id", value=self.taxonomy_id),
-            SearchField(name="lineage_taxids", value=self.lineage_taxids),
-            SearchField(name="lineage_name", value=self.lineage_name),
             SearchField(name="organism_id", value=self.organism_uuid),
             SearchField(name="rank", value=self.rank),
             SearchField(name="first_release_name", value=self.first_release_name),
@@ -211,7 +210,19 @@ class GenomeSearchDocument(BaseModel):
             SearchField(name="releases", value=self.releases),
         ]
 
-        # Search expects one field entry per genome group rather than a list-valued field.
+        # Search expects one field entry per multi-valued facet rather than list-valued fields.
+        fields.extend(
+            SearchField(name="lineage_taxon_id", value=lineage_taxon_id)
+            for lineage_taxon_id in self.lineage_taxon_id
+        )
+        fields.extend(
+            SearchField(name="lineage_common_name", value=lineage_common_name)
+            for lineage_common_name in self.lineage_common_name
+        )
+        fields.extend(
+            SearchField(name="lineage_scientific_name", value=lineage_scientific_name)
+            for lineage_scientific_name in self.lineage_scientific_name
+        )
         fields.extend(
             SearchField(name="genome_group_ids", value=genome_group_id)
             for genome_group_id in self.genome_group_ids
@@ -770,21 +781,21 @@ class GenomeSearchIndexer:
         return sorted(genome_group_ids)
 
     def _get_taxonomy_lineage(
-            self, taxonomy_session: Session, taxonomy_id: int
-    ) -> Tuple[List[int], List[str]]:
+        self, taxonomy_session: Session, taxonomy_id: int
+    ) -> dict[str, List[Union[int, str]]]:
         """
         Get taxonomy lineage for a given taxonomy_id.
 
         Returns:
-            - lineage_taxids: List of all taxon_ids from current to root
-            - lineage_names: List of ALL names (all name_classes) for all taxids in lineage
+            A mapping containing:
+            - lineage_taxon_id: all taxon_ids from current to root
+            - lineage_common_name: names with name_class = "common name"
+            - lineage_scientific_name: names with name_class = "scientific name"
 
         Args:
             taxonomy_session: Taxonomy database session
             taxonomy_id: The taxonomy ID to get lineage for
 
-        Returns:
-            (lineage_taxids, lineage_names) tuple
         """
         from ensembl.ncbi_taxonomy.api.utils import Taxonomy
         from ensembl.ncbi_taxonomy.models import NCBITaxonomy
@@ -794,26 +805,52 @@ class GenomeSearchIndexer:
         except NoResultFound:
             ancestors = []
 
-        # Build list of taxon_ids: current + all ancestors
-        lineage_taxids = [taxonomy_id]
+        # Build list of taxon_ids: current + all ancestors.
+        lineage_taxon_ids = [taxonomy_id]
         for ancestor in ancestors:
-            lineage_taxids.append(ancestor["taxon_id"])
+            lineage_taxon_ids.append(ancestor["taxon_id"])
 
-        # Query for ALL names (all name_class values) for all taxon_ids in the lineage
-        # exclude 'import date' entries.
-        # TODO: Add more exclusions on here!
-        all_names = (
-            taxonomy_session.query(NCBITaxonomy.name)
-            .filter(NCBITaxonomy.taxon_id.in_(lineage_taxids))
-            .filter(NCBITaxonomy.name_class != "import date")
+        # Query scientific and common names for all taxon_ids in the lineage.
+        # TODO: Check if we need to extend this to include more name_classes or tweak filter by rank
+        taxonomy_name_rows = (
+            taxonomy_session.query(NCBITaxonomy.taxon_id, NCBITaxonomy.name, NCBITaxonomy.name_class)
+            .filter(NCBITaxonomy.taxon_id.in_(lineage_taxon_ids))
+            .filter(NCBITaxonomy.name_class.in_(("scientific name", "common name")))
+            # Exclude these ranks to limit noise
+            .filter(NCBITaxonomy.rank.notin_((
+                    "acronym", "authority", "blast name", "equivalent name", "genbank common name",
+                    "import date", "in-part", "includes", "merged_taxon_id", "synonym", "type material"
+                ))
+            ) 
             .distinct()
             .all()
         )
 
-        # Extract just the name strings from the query results
-        lineage_names = [name[0] for name in all_names]
+        names_by_taxon_id = {
+            taxon_id: {"common name": [], "scientific name": []} for taxon_id in lineage_taxon_ids
+        }
+        # print(taxonomy_name_rows)
+        
+        for taxon_id, name, name_class in taxonomy_name_rows:
+            names_by_taxon_id[taxon_id][name_class].append(name)
 
-        return (lineage_taxids, lineage_names)
+        from pprint import pprint
+        # pprint(names_by_taxon_id)
+
+        lineage_common_names = []
+        lineage_scientific_names = []
+        for taxon_id in lineage_taxon_ids:
+            lineage_common_names.extend(names_by_taxon_id[taxon_id]["common name"])
+            lineage_scientific_names.extend(names_by_taxon_id[taxon_id]["scientific name"])
+
+        lineage_data = {
+            "lineage_taxon_id": lineage_taxon_ids,
+            "lineage_common_name": lineage_common_names,
+            "lineage_scientific_name": lineage_scientific_names,
+        }
+
+        # logger.info(lineage_data)
+        return lineage_data
 
     def create_search_document(
             self, metadata_session: Session, taxonomy_session: Session, genome: Genome, release: EnsemblRelease
@@ -866,15 +903,7 @@ class GenomeSearchIndexer:
             }
         )
 
-        lineage_taxids, lineage_names = self._get_taxonomy_lineage(
-            taxonomy_session, genome.organism.taxonomy_id
-        )
-        doc_data.update(
-            {
-                "lineage_taxids": lineage_taxids,
-                "lineage_name": lineage_names,
-            }
-        )
+        doc_data.update(self._get_taxonomy_lineage(taxonomy_session, genome.organism.taxonomy_id))
 
         return GenomeSearchDocument(**doc_data)
 
@@ -968,11 +997,11 @@ class GenomeSearchIndexer:
                                 error_message=f"Unexpected error: {str(e)}",
                                 exception=e,
                             )
-                
+
                 # sort GenomeSearchDocuments
                 all_entries = self.sort_results(all_entries)
                 all_entries = update_rank(all_entries)
-                
+
                 # convert to SearchEntry
                 # TODO turn to_search_entry into a model_serializer  
                 all_entries_as_search_entry = list(map(lambda d: d.to_search_entry(), all_entries))
@@ -1147,7 +1176,7 @@ class GenomeSearchIndexer:
                                 # sort GenomeSearchDocuments
                 search_entries = self.sort_results(search_entries)
                 search_entries = update_rank(search_entries)
-                
+
                 # convert to SearchEntry
                 # TODO turn to_search_entry into a model_serializer  
                 search_entries_as_search_entry = list(map(lambda d: d.to_search_entry(), search_entries))
@@ -1169,7 +1198,7 @@ class GenomeSearchIndexer:
 
                     if raise_on_errors:
                         error_collection.raise_if_errors()
-                
+
                 return SearchIndex(
                     name="ensemblNext",
                     release=newest_partial,
@@ -1187,7 +1216,7 @@ def update_rank(docs: List[GenomeSearchDocument]) -> List[GenomeSearchDocument]:
     """
     for i, d in enumerate(docs):
         d.rank = i + 1
-    
+
     return docs
 
 # ============================================================================

--- a/src/ensembl/production/metadata/api/search/search.py
+++ b/src/ensembl/production/metadata/api/search/search.py
@@ -789,7 +789,7 @@ class GenomeSearchIndexer:
         Returns:
             A mapping containing:
             - lineage_taxon_id: all taxon_ids from current to root
-            - lineage_common_name: names with name_class = "common name"
+            - lineage_common_name: preferred common names, using "genbank common name" when available
             - lineage_scientific_name: names with name_class = "scientific name"
 
         Args:
@@ -803,11 +803,7 @@ class GenomeSearchIndexer:
         try:
             ancestors = Taxonomy.fetch_ancestors(taxonomy_session, taxonomy_id)
         except NoResultFound:
-            return {
-                "lineage_taxon_id": [taxonomy_id],
-                "lineage_common_name": [],
-                "lineage_scientific_name": [],
-            }
+            ancestors = []
 
         # Build list of taxon_ids: current + all ancestors.
         lineage_taxon_ids = [taxonomy_id]
@@ -825,20 +821,28 @@ class GenomeSearchIndexer:
             "species",
         )
 
-        # Query scientific and common names for selected ranks in the lineage.
+        # Query scientific names and candidate common names for selected ranks in the lineage.
         taxonomy_name_rows = (
             taxonomy_session.query(NCBITaxonomy.taxon_id, NCBITaxonomy.name, NCBITaxonomy.name_class)
             .filter(NCBITaxonomy.taxon_id.in_(lineage_taxon_ids))
-            .filter(NCBITaxonomy.name_class.in_(("scientific name", "common name")))
+            .filter(NCBITaxonomy.name_class.in_(("scientific name", "genbank common name", "common name")))
             .filter(NCBITaxonomy.rank.in_(selected_ranks))
             .distinct()
             .all()
         )
 
         selected_taxon_ids = {taxon_id for taxon_id, name, name_class in taxonomy_name_rows}
+        if not selected_taxon_ids:
+            return {
+                "lineage_taxon_id": [taxonomy_id],
+                "lineage_common_name": [],
+                "lineage_scientific_name": [],
+            }
+
         lineage_taxon_ids = [taxon_id for taxon_id in lineage_taxon_ids if taxon_id in selected_taxon_ids]
         names_by_taxon_id = {
-            taxon_id: {"common name": [], "scientific name": []} for taxon_id in lineage_taxon_ids
+            taxon_id: {"genbank common name": [], "common name": [], "scientific name": []}
+            for taxon_id in lineage_taxon_ids
         }
 
         for taxon_id, name, name_class in taxonomy_name_rows:
@@ -847,7 +851,10 @@ class GenomeSearchIndexer:
         lineage_common_names = []
         lineage_scientific_names = []
         for taxon_id in lineage_taxon_ids:
-            lineage_common_names.extend(names_by_taxon_id[taxon_id]["common name"])
+            preferred_common_names = names_by_taxon_id[taxon_id]["genbank common name"]
+            if not preferred_common_names:
+                preferred_common_names = names_by_taxon_id[taxon_id]["common name"]
+            lineage_common_names.extend(preferred_common_names)
             lineage_scientific_names.extend(names_by_taxon_id[taxon_id]["scientific name"])
 
         lineage_data = {

--- a/src/tests/test_search.py
+++ b/src/tests/test_search.py
@@ -191,8 +191,9 @@ class TestGenomeSearchDocument:
             latest_release_type="integrated",
             is_latest_release_current=1,
             releases="112",
-            lineage_taxids=[9606, 9605, 9604],
-            lineage_name=["Homo sapiens", "Homo", "Hominidae"],
+            lineage_taxon_id=[9606, 9605, 9604],
+            lineage_common_name=["human"],
+            lineage_scientific_name=["Homo sapiens", "Homo", "Hominidae"],
             contig_n50=50000000,
             coding_genes=20000,
             genebuild_provider="Ensembl",
@@ -204,7 +205,7 @@ class TestGenomeSearchDocument:
         assert doc.is_reference is True
         assert doc.contig_n50 == 50000000
         assert doc.coding_genes == 20000
-        assert len(doc.lineage_taxids) == 3
+        assert len(doc.lineage_taxon_id) == 3
         assert doc.has_variation is False  # Default value
         assert doc.has_regulation is False  # Default value
         assert doc.rank == 0  # Default value
@@ -233,8 +234,9 @@ class TestGenomeSearchDocument:
             is_latest_release_current=1,
             releases="112",
             rank=10,
-            lineage_taxids=[9606],
-            lineage_name=["Homo sapiens"],
+            lineage_taxon_id=[9606],
+            lineage_common_name=["human"],
+            lineage_scientific_name=["Homo sapiens"],
             contig_n50=50000000,
             coding_genes=20000,
             has_variation=True,
@@ -268,8 +270,9 @@ class TestGenomeSearchDocument:
             latest_release_type="integrated",
             is_latest_release_current=1,
             releases="112",
-            lineage_taxids=[9606],
-            lineage_name=["Homo sapiens"],
+            lineage_taxon_id=[9606],
+            lineage_common_name=["human"],
+            lineage_scientific_name=["Homo sapiens"],
             contig_n50=50000000,
             coding_genes=20000,
             genebuild_provider="Ensembl",
@@ -278,11 +281,46 @@ class TestGenomeSearchDocument:
         )
 
         entry = doc.to_search_entry()
-        genome_group_fields = [
-            field for field in entry.fields if field.name == "genome_group_ids"
-        ]
+        genome_group_fields = [field for field in entry.fields if field.name == "genome_group_ids"]
 
         assert [field.value for field in genome_group_fields] == [1, 2]
+
+    def test_document_serializes_lineage_as_repeated_fields(self, test_dbs):
+        """Test lineage values are emitted as repeated search fields."""
+        doc = GenomeSearchDocument(
+            genome_uuid="test-uuid",
+            scientific_name="Homo sapiens",
+            assembly_name="GRCh38",
+            accession="GCA_000001405.15",
+            is_reference=True,
+            species_taxonomy_id=9606,
+            taxonomy_id=9606,
+            organism_uuid="test-organism-uuid",
+            first_release_name="112",
+            first_release_type="integrated",
+            latest_release_name="112",
+            latest_release_type="integrated",
+            is_latest_release_current=1,
+            releases="112",
+            lineage_taxon_id=[9606, 9605],
+            lineage_common_name=["human"],
+            lineage_scientific_name=["Homo sapiens", "Homo"],
+            contig_n50=50000000,
+            coding_genes=20000,
+            genebuild_provider="Ensembl",
+            genebuild_method_display="Import",
+        )
+
+        entry = doc.to_search_entry()
+
+        assert [field.value for field in entry.fields if field.name == "lineage_taxon_id"] == [9606, 9605]
+        assert [field.value for field in entry.fields if field.name == "lineage_common_name"] == ["human"]
+        assert [field.value for field in entry.fields if field.name == "lineage_scientific_name"] == [
+            "Homo sapiens",
+            "Homo",
+        ]
+        assert not any(field.name == "lineage_taxids" for field in entry.fields)
+        assert not any(field.name == "lineage_name" for field in entry.fields)
 
     def test_document_missing_required_field(self, test_dbs):
         """Test document creation fails when required field is missing."""
@@ -311,8 +349,9 @@ class TestGenomeSearchDocument:
                 latest_release_type="integrated",
                 is_latest_release_current=1,
                 releases="112",
-                lineage_taxids=[9606],
-                lineage_name=["Homo sapiens"],
+                lineage_taxon_id=[9606],
+                lineage_common_name=["human"],
+                lineage_scientific_name=["Homo sapiens"],
                 contig_n50=50000000,
                 coding_genes=20000,
                 genebuild_provider="Ensembl",
@@ -336,8 +375,9 @@ class TestGenomeSearchDocument:
             latest_release_type="integrated",
             is_latest_release_current=1,
             releases="112",
-            lineage_taxids=[9606],
-            lineage_name=["Homo sapiens"],
+            lineage_taxon_id=[9606],
+            lineage_common_name=["human"],
+            lineage_scientific_name=["Homo sapiens"],
             contig_n50=50000000,
             coding_genes=20000,
             genebuild_provider="Ensembl",
@@ -367,8 +407,9 @@ class TestGenomeSearchDocument:
                 latest_release_type="integrated",
                 is_latest_release_current=1,
                 releases="112",
-                lineage_taxids=[9606],
-                lineage_name=["Homo sapiens"],
+                lineage_taxon_id=[9606],
+                lineage_common_name=["human"],
+                lineage_scientific_name=["Homo sapiens"],
                 contig_n50=50000000,
                 coding_genes=20000,
                 genebuild_provider="Ensembl",
@@ -390,28 +431,27 @@ class TestGenomeSearchDocument:
                 latest_release_type="integrated",
                 is_latest_release_current=1,
                 releases="112",
-                lineage_taxids=[9606],
-                lineage_name=["Homo sapiens"],
+                lineage_taxon_id=[9606],
+                lineage_common_name=["human"],
+                lineage_scientific_name=["Homo sapiens"],
                 contig_n50=50000000,
                 coding_genes=20000,
-                
                 genebuild_provider="Ensembl",
                 genebuild_method_display="Import",
                 rank=0,
-            )
+            ),
         ]
-        
+
         assert docs[0].rank == 999
         assert docs[1].rank == 0
-        
+
         docs = update_rank(docs)
-        
+
         assert docs[0].rank == 1
         assert docs[1].rank == 2
-        
+
         assert docs[0].genome_uuid == "test-uuid"
         assert docs[1].genome_uuid == "test-uuid_2"
-        
 
 
 @pytest.mark.parametrize(
@@ -1061,16 +1101,16 @@ class TestGenomeSearchIndexer:
                 genome = metadata_session.query(Genome).first()
 
                 if genome:
-                    lineage_taxids, lineage_names = indexer._get_taxonomy_lineage(
-                        taxonomy_session, genome.organism.taxonomy_id
-                    )
+                    lineage = indexer._get_taxonomy_lineage(taxonomy_session, genome.organism.taxonomy_id)
 
-                    assert isinstance(lineage_taxids, list)
-                    assert isinstance(lineage_names, list)
-                    assert len(lineage_taxids) > 0
-                    assert len(lineage_names) > 0
-                    assert all(isinstance(tid, int) for tid in lineage_taxids)
-                    assert all(isinstance(name, str) for name in lineage_names)
+                    assert isinstance(lineage["lineage_taxon_id"], list)
+                    assert isinstance(lineage["lineage_common_name"], list)
+                    assert isinstance(lineage["lineage_scientific_name"], list)
+                    assert len(lineage["lineage_taxon_id"]) > 0
+                    assert len(lineage["lineage_scientific_name"]) > 0
+                    assert all(isinstance(tid, int) for tid in lineage["lineage_taxon_id"])
+                    assert all(isinstance(name, str) for name in lineage["lineage_common_name"])
+                    assert all(isinstance(name, str) for name in lineage["lineage_scientific_name"])
 
     def test_get_taxonomy_lineage_not_found(self, test_dbs):
         """Test _get_taxonomy_lineage handles missing taxonomy gracefully."""
@@ -1080,11 +1120,12 @@ class TestGenomeSearchIndexer:
 
         with test_dbs["ncbi_taxonomy"].dbc.session_scope() as taxonomy_session:
             # Use a taxonomy ID that doesn't exist
-            lineage_taxids, lineage_names = indexer._get_taxonomy_lineage(taxonomy_session, 999999999)
+            lineage = indexer._get_taxonomy_lineage(taxonomy_session, 999999999)
 
             # Should return just the requested taxid and empty names
-            assert isinstance(lineage_taxids, list)
-            assert isinstance(lineage_names, list)
+            assert lineage["lineage_taxon_id"] == [999999999]
+            assert lineage["lineage_common_name"] == []
+            assert lineage["lineage_scientific_name"] == []
 
     def test_create_search_document_success(self, test_dbs):
         """Test create_search_document successfully creates a document."""

--- a/src/tests/test_search.py
+++ b/src/tests/test_search.py
@@ -1124,6 +1124,30 @@ class TestGenomeSearchIndexer:
                     }
                     assert lineage_ranks.issubset(selected_ranks)
 
+    def test_get_taxonomy_lineage_prefers_genbank_common_name(self, test_dbs):
+        """Test lineage common names prefer genbank common name over common name."""
+        metadata_uri = test_dbs["ensembl_genome_metadata"].dbc.url
+        taxonomy_uri = test_dbs["ncbi_taxonomy"].dbc.url
+        indexer = GenomeSearchIndexer(metadata_uri, taxonomy_uri)
+
+        with test_dbs["ncbi_taxonomy"].dbc.session_scope() as taxonomy_session:
+            lineage = indexer._get_taxonomy_lineage(taxonomy_session, 3702)
+
+            assert "thale cress" in lineage["lineage_common_name"]
+            assert "mouse-ear cress" not in lineage["lineage_common_name"]
+            assert "thale-cress" not in lineage["lineage_common_name"]
+
+    def test_get_taxonomy_lineage_falls_back_to_common_name(self, test_dbs):
+        """Test lineage common names fall back when genbank common name is unavailable."""
+        metadata_uri = test_dbs["ensembl_genome_metadata"].dbc.url
+        taxonomy_uri = test_dbs["ncbi_taxonomy"].dbc.url
+        indexer = GenomeSearchIndexer(metadata_uri, taxonomy_uri)
+
+        with test_dbs["ncbi_taxonomy"].dbc.session_scope() as taxonomy_session:
+            lineage = indexer._get_taxonomy_lineage(taxonomy_session, 562)
+
+            assert "E. coli" in lineage["lineage_common_name"]
+
     def test_get_taxonomy_lineage_not_found(self, test_dbs):
         """Test _get_taxonomy_lineage handles missing taxonomy gracefully."""
         metadata_uri = test_dbs["ensembl_genome_metadata"].dbc.url

--- a/src/tests/test_search.py
+++ b/src/tests/test_search.py
@@ -1092,6 +1092,8 @@ class TestGenomeSearchIndexer:
 
     def test_get_taxonomy_lineage(self, test_dbs):
         """Test _get_taxonomy_lineage retrieves taxonomy information."""
+        from ensembl.ncbi_taxonomy.models import NCBITaxonomy
+
         metadata_uri = test_dbs["ensembl_genome_metadata"].dbc.url
         taxonomy_uri = test_dbs["ncbi_taxonomy"].dbc.url
         indexer = GenomeSearchIndexer(metadata_uri, taxonomy_uri)
@@ -1111,6 +1113,16 @@ class TestGenomeSearchIndexer:
                     assert all(isinstance(tid, int) for tid in lineage["lineage_taxon_id"])
                     assert all(isinstance(name, str) for name in lineage["lineage_common_name"])
                     assert all(isinstance(name, str) for name in lineage["lineage_scientific_name"])
+
+                    selected_ranks = {"domain", "kingdom", "phylum", "class", "order", "family", "genus", "species"}
+                    lineage_ranks = {
+                        rank
+                        for rank, in taxonomy_session.query(NCBITaxonomy.rank)
+                        .filter(NCBITaxonomy.taxon_id.in_(lineage["lineage_taxon_id"]))
+                        .distinct()
+                        .all()
+                    }
+                    assert lineage_ranks.issubset(selected_ranks)
 
     def test_get_taxonomy_lineage_not_found(self, test_dbs):
         """Test _get_taxonomy_lineage handles missing taxonomy gracefully."""


### PR DESCRIPTION
### Changes
Update taxonomy dump logic and structure in search dump script

<details>
<summary>
Example of Ecoli and Human fields (Updated to have 8 specific ranks)
</summary>

```json
{
  "name": "ensemblNext",
  "release": "2026-05-06",
  "entry_count": 1,
  "entries": [
    {
      "fields": [
        {
          "name": "id",
          "value": "a73351f7-93e7-11ec-a39d-005056b38ce3"
        },
        {
          "name": "common_name",
          "value": "Escherichia coli K-12"
        },
        ...
        {
          "name": "lineage_taxon_id",
          "value": 2
        },
        {
          "name": "lineage_taxon_id",
          "value": 543
        },
        {
          "name": "lineage_taxon_id",
          "value": 561
        },
        {
          "name": "lineage_taxon_id",
          "value": 562
        },
        {
          "name": "lineage_taxon_id",
          "value": 1224
        },
        {
          "name": "lineage_taxon_id",
          "value": 1236
        },
        {
          "name": "lineage_taxon_id",
          "value": 91347
        },
        {
          "name": "lineage_taxon_id",
          "value": 3379134
        },
        {
          "name": "lineage_common_name",
          "value": "eubacteria"
        },
        {
          "name": "lineage_common_name",
          "value": "E. coli"
        },
        {
          "name": "lineage_common_name",
          "value": "purple photosynthetic bacteria and relatives"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Bacteria"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Enterobacteriaceae"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Escherichia"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Escherichia coli"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Pseudomonadota"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Gammaproteobacteria"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Enterobacterales"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Pseudomonadati"
        }
      ]
    },
    {
      "fields": [
        {
          "name": "id",
          "value": "feb866f5-ad6e-40c0-a173-ffa6c19c70f2"
        },
        {
          "name": "common_name",
          "value": "Human"
        },
        ...
        {
          "name": "lineage_taxon_id",
          "value": 9606
        },
        {
          "name": "lineage_taxon_id",
          "value": 2759
        },
        {
          "name": "lineage_taxon_id",
          "value": 7711
        },
        {
          "name": "lineage_taxon_id",
          "value": 9443
        },
        {
          "name": "lineage_taxon_id",
          "value": 9604
        },
        {
          "name": "lineage_taxon_id",
          "value": 9605
        },
        {
          "name": "lineage_taxon_id",
          "value": 33208
        },
        {
          "name": "lineage_taxon_id",
          "value": 40674
        },
        {
          "name": "lineage_common_name",
          "value": "human"
        },
        {
          "name": "lineage_common_name",
          "value": "eucaryotes"
        },
        {
          "name": "lineage_common_name",
          "value": "chordates"
        },
        {
          "name": "lineage_common_name",
          "value": "great apes"
        },
        {
          "name": "lineage_common_name",
          "value": "humans"
        },
        {
          "name": "lineage_common_name",
          "value": "metazoans"
        },
        {
          "name": "lineage_common_name",
          "value": "mammals"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Homo sapiens"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Eukaryota"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Chordata"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Primates"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Hominidae"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Homo"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Metazoa"
        },
        {
          "name": "lineage_scientific_name",
          "value": "Mammalia"
        }
      ]
    }
  ]
}
```
</details>

### To check

- [x] Are the field names adequate (`lineage_taxon_id`, `lineage_scientific_name` and `lineage_common_name` )? Yes
- [x] Do we want to get rid of `root`? Yes
- [x] Do we want to refine the `rank`s or `class_name`s? No for now
- [x] Does the content look as expected? Yes