### PR TITLE
hotfix: Limit specific keyword genome lookups to current releases

### DIFF
--- a/src/ensembl/production/metadata/api/adaptors/genome.py
+++ b/src/ensembl/production/metadata/api/adaptors/genome.py
@@ -452,8 +452,13 @@ class GenomeAdaptor(BaseAdaptor):
             # otherwise pick all releases up to the specified release version in the if condition above
             genome_query = genome_query.where(
                 or_(
-                    EnsemblRelease.is_current == 1,
-                    GenomeRelease.is_current == 1
+                    and_(
+                        EnsemblRelease.release_type == "partial",
+                        GenomeRelease.is_current == 1),
+                    and_(
+                        EnsemblRelease.release_type == "integrated", 
+                        EnsemblRelease.is_current == 1
+                    )
                 )       
             )
             

--- a/src/ensembl/production/metadata/api/adaptors/genome.py
+++ b/src/ensembl/production/metadata/api/adaptors/genome.py
@@ -447,7 +447,16 @@ class GenomeAdaptor(BaseAdaptor):
             genome_query = genome_query.filter(EnsemblRelease.status == ReleaseStatus.RELEASED)
         if release_version is not None and release_version > 0:
             genome_query = genome_query.where(EnsemblRelease.version <= release_version)
-
+        else:
+            # Pick only current integrated and partial releases, if release_version is not specified, 
+            # otherwise pick all releases up to the specified release version in the if condition above
+            genome_query = genome_query.where(
+                or_(
+                    EnsemblRelease.is_current == 1,
+                    GenomeRelease.is_current == 1
+                )       
+            )
+            
         provided_fields = [
             tolid,
             assembly_accession_id,
@@ -510,6 +519,7 @@ class GenomeAdaptor(BaseAdaptor):
             return []
 
         logger.debug(f"bySpecificKeyword: {genome_query} {release_version}")
+        print(f"bySpecificKeyword: {genome_query} {release_version}")
         with self.metadata_db.session_scope() as session:
             session.expire_on_commit = False
             return session.execute(genome_query).all()


### PR DESCRIPTION
### Changes

Limit specific keyword genome lookups to current releases when no release version is provided

This gRPC call

```shell
grpcurl -plaintext -d '{
  "assemblyAccessionId": "GCA_964188405.1"
}' OUR_SERVICE ensembl_metadata.EnsemblMetadata.GetGenomesBySpecificKeyword
```

Returns two partial genomes instead of one, because the filter on `GenomeRelease.is_current == 1` for partials was missing (as well as `EnsemblRelease.is_current == 1` for integrated)

This PR fixes that.