### PR TITLE
Add fetch_top_regions_by_genome_uuid method

### DIFF
--- a/src/ensembl/production/metadata/api/adaptors/genome.py
+++ b/src/ensembl/production/metadata/api/adaptors/genome.py
@@ -620,6 +620,74 @@ class GenomeAdaptor(BaseAdaptor):
             genome_uuid=genome_uuid, chromosomal_only=chromosomal_only
         )
 
+    def fetch_top_regions_by_genome_uuid(self, genome_uuid, region_type=None, limit=100):
+        """
+        Fetches the top assembly regions for a genome.
+
+        Chromosomal regions are ordered by chromosome rank. Non-chromosomal regions are
+        ordered by length descending, then name. When no region type is provided,
+        chromosomal regions are returned first and non-chromosomal regions fill the
+        remaining limit.
+
+        Args:
+            genome_uuid (str): Genome UUID to filter by.
+            region_type (str or None): Public region type filter. "chromosome"
+                maps to chromosomal regions; other values map to non-chromosomal
+                assembly_sequence.type values.
+            limit (int): Maximum number of regions to return.
+
+        Returns:
+            list: A list of fetched sequence rows.
+        """
+        if not genome_uuid or limit <= 0:
+            return []
+
+        def top_regions_select():
+            return db.select(
+                Genome, Assembly, AssemblySequence
+            ).select_from(Genome) \
+                .join(Assembly, Assembly.assembly_id == Genome.assembly_id) \
+                .join(AssemblySequence, AssemblySequence.assembly_id == Assembly.assembly_id) \
+                .filter(Genome.genome_uuid == genome_uuid)
+
+        def fetch_chromosomal(session, result_limit):
+            chromosomal_select = top_regions_select() \
+                .filter(AssemblySequence.chromosomal == 1) \
+                .order_by(
+                    AssemblySequence.chromosome_rank,
+                    AssemblySequence.name,
+                ) \
+                .limit(result_limit)
+            return session.execute(chromosomal_select).all()
+
+        def fetch_non_chromosomal(session, result_limit, assembly_sequence_type=None):
+            non_chromosomal_select = top_regions_select() \
+                .filter(AssemblySequence.chromosomal == 0)
+            if assembly_sequence_type is not None:
+                non_chromosomal_select = non_chromosomal_select.filter(
+                    AssemblySequence.type == assembly_sequence_type
+                )
+            non_chromosomal_select = non_chromosomal_select \
+                .order_by(
+                    AssemblySequence.length.desc(),
+                    AssemblySequence.name,
+                ) \
+                .limit(result_limit)
+            return session.execute(non_chromosomal_select).all()
+
+        with self.metadata_db.session_scope() as session:
+            session.expire_on_commit = False
+            if region_type == "chromosome":
+                return fetch_chromosomal(session, limit)
+            if region_type is not None:
+                return fetch_non_chromosomal(session, limit, region_type)
+
+            top_regions = fetch_chromosomal(session, limit)
+            remaining_limit = limit - len(top_regions)
+            if remaining_limit > 0:
+                top_regions.extend(fetch_non_chromosomal(session, remaining_limit))
+            return top_regions
+
     def fetch_sequences_by_assembly_accession(
             self, assembly_accession, chromosomal_only=False
     ):

--- a/src/tests/test_grpc_genome.py
+++ b/src/tests/test_grpc_genome.py
@@ -225,6 +225,70 @@ class TestGRPCGenomeAdaptor:
         for result in sequences:
             assert result.AssemblySequence.accession == expected_output
 
+    def test_fetch_top_regions_by_genome_uuid_chromosome_type(self, genome_conn):
+        regions = genome_conn.fetch_top_regions_by_genome_uuid(
+            "3704ceb1-948d-11ec-a39d-005056b38ce3",
+            region_type="chromosome",
+            limit=3,
+        )
+
+        assert [region.AssemblySequence.name for region in regions] == ["1", "10", "11"]
+        assert [region.AssemblySequence.chromosomal for region in regions] == [1, 1, 1]
+        assert [region.AssemblySequence.chromosome_rank for region in regions] == [1, 10, 11]
+
+    def test_fetch_top_regions_by_genome_uuid_non_chromosomal_type(self, genome_conn):
+        regions = genome_conn.fetch_top_regions_by_genome_uuid(
+            "2020e8d5-4d87-47af-be78-0b15e48970a7",
+            region_type="primary_assembly",
+            limit=3,
+        )
+
+        assert [region.AssemblySequence.name for region in regions] == [
+            "JAGYYT010000006.1",
+            "JAGYYT010000009.1",
+            "JAGYYT010000002.1",
+        ]
+        assert [region.AssemblySequence.chromosomal for region in regions] == [0, 0, 0]
+        assert [region.AssemblySequence.length for region in regions] == [
+            158663023,
+            118296892,
+            55482364,
+        ]
+
+    def test_fetch_top_regions_by_genome_uuid_defaults_to_chromosomal_then_non_chromosomal(self, genome_conn):
+        regions = genome_conn.fetch_top_regions_by_genome_uuid(
+            "3704ceb1-948d-11ec-a39d-005056b38ce3",
+            limit=12,
+        )
+
+        assert len(regions) == 12
+        assert [region.AssemblySequence.name for region in regions[:10]] == [
+            "1",
+            "10",
+            "11",
+            "12",
+            "13",
+            "14",
+            "15",
+            "16",
+            "17",
+            "18",
+        ]
+        assert [region.AssemblySequence.chromosomal for region in regions[:10]] == [1] * 10
+        assert [region.AssemblySequence.name for region in regions[10:]] == [
+            "GL000192.1",
+            "GL000194.1",
+        ]
+        assert [region.AssemblySequence.chromosomal for region in regions[10:]] == [0, 0]
+
+    def test_fetch_top_regions_by_genome_uuid_empty_inputs(self, genome_conn):
+        assert genome_conn.fetch_top_regions_by_genome_uuid(None) == []
+        assert genome_conn.fetch_top_regions_by_genome_uuid("missing-genome-uuid") == []
+        assert genome_conn.fetch_top_regions_by_genome_uuid(
+            "3704ceb1-948d-11ec-a39d-005056b38ce3",
+            limit=0,
+        ) == []
+
     @pytest.mark.parametrize(
         "genome_uuid, dataset_uuid, status, expected_dataset_uuid, expected_count",
         [


### PR DESCRIPTION
### Changes

This PR Adds a dedicated fetch_top_regions_by_genome_uuid() adaptor method for top-region queries, pushing filtering, ordering, and limiting into the database instead of relying on callers to fetch all sequence rows and slice in Python.

### Related Jira ticket
https://embl.atlassian.net/browse/ENSWBSITES-3014

### Related PRs
https://github.com/Ensembl/ensembl-web-metadata-api/pull/97