### PR TITLE
Update detch genome to include GenomeRelease in query

### DIFF
--- a/src/ensembl/production/metadata/api/adaptors/genome.py
+++ b/src/ensembl/production/metadata/api/adaptors/genome.py
@@ -301,7 +301,7 @@ class GenomeAdaptor(BaseAdaptor):
 
         if taxonomy_id is not None:
             genome_select = genome_select.filter(Organism.taxonomy_id.in_(taxonomy_id))
-        genome_select = genome_select.add_columns(EnsemblRelease, EnsemblSite) \
+        genome_select = genome_select.add_columns(GenomeRelease, EnsemblRelease, EnsemblSite) \
             .join(GenomeRelease) \
             .join(EnsemblRelease) \
             .join(EnsemblSite)


### PR DESCRIPTION
Tiny PR updating `fetch_genome` to include `GenomeRelease` in query

This is needed in `explain` endpoint in web metadata REST API for it to be able to process genomes in partial releases (*)

(*) Related PR: https://github.com/Ensembl/ensembl-web-metadata-api/pull/96