### PR TITLE
Update VEP file path

### DIFF
--- a/src/ensembl/production/metadata/api/adaptors/vep.py
+++ b/src/ensembl/production/metadata/api/adaptors/vep.py
@@ -17,6 +17,7 @@ from sqlalchemy.orm import aliased
 from ensembl.utils.database import DBConnection
 
 from ensembl.production.metadata.api.adaptors.base import BaseAdaptor
+from ensembl.production.metadata.api.factories.utils import format_accession_path
 from ensembl.production.metadata.api.models import Organism, Assembly, DatasetAttribute, Genome, GenomeDataset, Dataset
 
 
@@ -84,11 +85,16 @@ class VepAdaptor(BaseAdaptor):
             # Format last geneset update
             last_geneset_update = re.sub(r"-", "_", result.last_geneset_update)
 
+            formatted_accession_path = format_accession_path(result.assembly_accession)
+
             # Construct the locations
-            faa_location = f"{scientific_name}/{result.assembly_accession}/vep/genome/softmasked.fa.bgz"
+            faa_location = (
+                f"{formatted_accession_path}/{result.annotation_source}/"
+                f"{last_geneset_update}/vep/softmasked.fa.bgz"
+            )
             gff_location = (
-                f"{scientific_name}/{result.assembly_accession}/vep/"
-                f"{result.annotation_source}/geneset/{last_geneset_update}/genes.gff3.bgz"
+                f"{formatted_accession_path}/{result.annotation_source}/"
+                f"{last_geneset_update}/vep/genes.gff3.bgz"
             )
 
             # Return based on the `file` argument

--- a/src/ensembl/production/metadata/api/adaptors/vep.py
+++ b/src/ensembl/production/metadata/api/adaptors/vep.py
@@ -90,11 +90,11 @@ class VepAdaptor(BaseAdaptor):
             # Construct the locations
             faa_location = (
                 f"{formatted_accession_path}/{result.annotation_source}/"
-                f"{last_geneset_update}/vep/softmasked.fa.bgz"
+                f"{last_geneset_update}/genome/unmasked.fa.bgz"
             )
             gff_location = (
                 f"{formatted_accession_path}/{result.annotation_source}/"
-                f"{last_geneset_update}/vep/genes.gff3.bgz"
+                f"{last_geneset_update}/geneset/genes.gff3.bgz"
             )
 
             # Return based on the `file` argument

--- a/src/tests/test_protobuf_msg_factory.py
+++ b/src/tests/test_protobuf_msg_factory.py
@@ -253,16 +253,16 @@ class TestClass:
                 # Human
                 "65d4f21f-695a-4ed0-be67-5732a551fea4",
                 {
-                    "faaLocation": "Homo_sapiens/GCA_018473295.1/vep/genome/softmasked.fa.bgz",
-                    "gffLocation": "Homo_sapiens/GCA_018473295.1/vep/ensembl/geneset/2022_08/genes.gff3.bgz"
+                    "faaLocation": "GCA/018/473/295/1/ensembl/2022_08/vep/softmasked.fa.bgz",
+                    "gffLocation": "GCA/018/473/295/1/ensembl/2022_08/vep/genes.gff3.bgz"
                 }
             ),
             (
                 # Ecoli
                 "a73351f7-93e7-11ec-a39d-005056b38ce3",
                 {
-                    'faaLocation': 'Escherichia_coli_str_K_12_substr_MG1655_str_K12/GCA_000005845.2/vep/genome/softmasked.fa.bgz',
-                    'gffLocation': 'Escherichia_coli_str_K_12_substr_MG1655_str_K12/GCA_000005845.2/vep/community/geneset/2018_09/genes.gff3.bgz'
+                    'faaLocation': 'GCA/000/005/845/2/community/2018_09/vep/softmasked.fa.bgz',
+                    'gffLocation': 'GCA/000/005/845/2/community/2018_09/vep/genes.gff3.bgz'
                 }
             )
         ]

--- a/src/tests/test_protobuf_msg_factory.py
+++ b/src/tests/test_protobuf_msg_factory.py
@@ -253,16 +253,16 @@ class TestClass:
                 # Human
                 "65d4f21f-695a-4ed0-be67-5732a551fea4",
                 {
-                    "faaLocation": "GCA/018/473/295/1/ensembl/2022_08/vep/softmasked.fa.bgz",
-                    "gffLocation": "GCA/018/473/295/1/ensembl/2022_08/vep/genes.gff3.bgz"
+                    "faaLocation": "GCA/018/473/295/1/ensembl/2022_08/genome/unmasked.fa.bgz",
+                    "gffLocation": "GCA/018/473/295/1/ensembl/2022_08/geneset/genes.gff3.bgz"
                 }
             ),
             (
                 # Ecoli
                 "a73351f7-93e7-11ec-a39d-005056b38ce3",
                 {
-                    'faaLocation': 'GCA/000/005/845/2/community/2018_09/vep/softmasked.fa.bgz',
-                    'gffLocation': 'GCA/000/005/845/2/community/2018_09/vep/genes.gff3.bgz'
+                    'faaLocation': 'GCA/000/005/845/2/community/2018_09/genome/unmasked.fa.bgz',
+                    'gffLocation': 'GCA/000/005/845/2/community/2018_09/geneset/genes.gff3.bgz'
                 }
             )
         ]

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -954,16 +954,16 @@ class TestUtils:
                 # Human
                 "65d4f21f-695a-4ed0-be67-5732a551fea4",
                 {
-                    "faaLocation": "GCA/018/473/295/1/ensembl/2022_08/vep/softmasked.fa.bgz",
-                    "gffLocation": "GCA/018/473/295/1/ensembl/2022_08/vep/genes.gff3.bgz"
+                    "faaLocation": "GCA/018/473/295/1/ensembl/2022_08/genome/unmasked.fa.bgz",
+                    "gffLocation": "GCA/018/473/295/1/ensembl/2022_08/geneset/genes.gff3.bgz"
                 }
             ),
             (
                 # Ecoli
                 "a73351f7-93e7-11ec-a39d-005056b38ce3",
                 {
-                    'faaLocation': 'GCA/000/005/845/2/community/2018_09/vep/softmasked.fa.bgz',
-                    'gffLocation': 'GCA/000/005/845/2/community/2018_09/vep/genes.gff3.bgz'
+                    'faaLocation': 'GCA/000/005/845/2/community/2018_09/genome/unmasked.fa.bgz',
+                    'gffLocation': 'GCA/000/005/845/2/community/2018_09/geneset/genes.gff3.bgz'
                 }
             ),
             (

--- a/src/tests/test_utils.py
+++ b/src/tests/test_utils.py
@@ -954,16 +954,16 @@ class TestUtils:
                 # Human
                 "65d4f21f-695a-4ed0-be67-5732a551fea4",
                 {
-                    "faaLocation": "Homo_sapiens/GCA_018473295.1/vep/genome/softmasked.fa.bgz",
-                    "gffLocation": "Homo_sapiens/GCA_018473295.1/vep/ensembl/geneset/2022_08/genes.gff3.bgz"
+                    "faaLocation": "GCA/018/473/295/1/ensembl/2022_08/vep/softmasked.fa.bgz",
+                    "gffLocation": "GCA/018/473/295/1/ensembl/2022_08/vep/genes.gff3.bgz"
                 }
             ),
             (
                 # Ecoli
                 "a73351f7-93e7-11ec-a39d-005056b38ce3",
                 {
-                    'faaLocation': 'Escherichia_coli_str_K_12_substr_MG1655_str_K12/GCA_000005845.2/vep/genome/softmasked.fa.bgz',
-                    'gffLocation': 'Escherichia_coli_str_K_12_substr_MG1655_str_K12/GCA_000005845.2/vep/community/geneset/2018_09/genes.gff3.bgz'
+                    'faaLocation': 'GCA/000/005/845/2/community/2018_09/vep/softmasked.fa.bgz',
+                    'gffLocation': 'GCA/000/005/845/2/community/2018_09/vep/genes.gff3.bgz'
                 }
             ),
             (


### PR DESCRIPTION
### Description

Fixes [ENSWBSITES-3023](https://embl.atlassian.net/browse/ENSWBSITES-3023)

- Update VEP file path

Before:
```
{
"faa_location": "Homo_sapiens/GCA_000001405.29/vep/genome/softmasked.fa.bgz",
"gff_location": "Homo_sapiens/GCA_000001405.29/vep/ensembl/geneset/2024_11/genes.gff3.bgz"
}
```

After:
```
{
"faa_location": "GCA/000/001/405/29/ensembl/2024_11/vep/softmasked.fa.bgz",
"gff_location": "GCA/000/001/405/29/ensembl/2024_11/vep/genes.gff3.bgz"
}
```

- `fetch_vep_locations` is used in web-metadata-api, any error thrown is handled in web-metadata-api 
